### PR TITLE
Basic support of ebook building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+INPUT=$(shell find part* -iname "*.md")
+all: pdf mobi
+epub: $(INPUT) 
+	pandoc -o chef-book.epub --toc --toc-depth=2 title.txt $^
+mobi: epub
+	kindlegen chef-book.epub
+pdf: $(INPUT)
+	pandoc -o chef-book.pdf --latex-engine=xelatex $^
+clean:
+	rm -f chef-book.{epub,mobi,pdf}
+

--- a/title.txt
+++ b/title.txt
@@ -1,0 +1,2 @@
+% The chef-book
+% JJ Asghar


### PR DESCRIPTION
Requires `pandoc`, `kindlegen` (for mobi) and `pdflatex` (for pdf)
PDF building has some issues – pdflatex complains about fancy unicode symbols. Adding `--latex-engine=xelatex` to pdflatex params helps but it seems now it just skip this fancy symbols. Probably some template [magic](http://stackoverflow.com/questions/18178084/pandoc-and-foreign-characters) should help.
Also some heading adjustment is required – pandoc uses headings to generate TOC, now it looks a little bit clumsy.