### PR TITLE
Update 07-vagrant-provisioning-vs-local-chef-zero.md

### DIFF
--- a/part2/07-vagrant-provisioning-vs-local-chef-zero.md
+++ b/part2/07-vagrant-provisioning-vs-local-chef-zero.md
@@ -72,7 +72,7 @@ Vagrant.configure("2") do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.host_name = 'chef-book'
   #config.vm.provision :shell, :inline => $script
-  config.vm.provision "chef_client" do |chef|
+  config.vm.provision "chef_solo" do |chef|
     chef.add_recipe "base"
   end
 end


### PR DESCRIPTION
Fixed typo in Vagrantfile when provisioning from vagrant.
Provision should be `chef_solo` instead of `chef_client`.